### PR TITLE
Added headers to all scripts so that Ansible recognizes them

### DIFF
--- a/doitforme.sh
+++ b/doitforme.sh
@@ -1,3 +1,4 @@
+#! /bin/sh
 wget -q --tries=10 --timeout=20 --spider http://google.com
 if [[ $? -eq 0 ]]; then
         echo "Online"

--- a/overlay/chip/install.sh
+++ b/overlay/chip/install.sh
@@ -1,3 +1,4 @@
+#! /bin/sh
 if [ "$EUID" -ne 0 ]
   then echo "Please run as root"
   exit

--- a/overlay/load.sh
+++ b/overlay/load.sh
@@ -1,3 +1,5 @@
+#! /bin/sh
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 sudo rmdir /sys/kernel/config/device-tree/overlays/JKW_TZATZIFFY/ >/dev/null 2>&1;
 sudo mkdir /sys/kernel/config/device-tree/overlays/JKW_TZATZIFFY

--- a/projects/flickr/install.sh
+++ b/projects/flickr/install.sh
@@ -1,1 +1,3 @@
+#! /bin/sh
+
 sudo apt-get install python3-pil.imagetk python3-pil python3-tk

--- a/projects/radio/ffn.sh
+++ b/projects/radio/ffn.sh
@@ -1,1 +1,2 @@
+#! /bin/sh
 mpg123 -a default:CARD=DAC http://player.ffn.de/ffn.mp3

--- a/projects/radio/prepare.sh
+++ b/projects/radio/prepare.sh
@@ -1,2 +1,4 @@
+#! /bin/sh
+
 sudo apt update
 sudo apt install screen rtmpdump mplayer -y

--- a/projects/radio/rtl.sh
+++ b/projects/radio/rtl.sh
@@ -1,1 +1,3 @@
+#! /bin/sh
+
 mpg123 -a default:CARD=DAC -@http://webradio.89.0rtl.de/livestream128.m3u

--- a/projects/radio/stop.sh
+++ b/projects/radio/stop.sh
@@ -1,1 +1,3 @@
+#! /bin/sh
+
 screen -X -S "radio_screen" quit

--- a/scripts/css.sh
+++ b/scripts/css.sh
@@ -1,4 +1,4 @@
- #!/bin/bash
+#!/bin/bash
 LP=""
 B=`cat /sys/class/backlight/backlight/actual_brightness`
 

--- a/scripts/speaker_mute.sh
+++ b/scripts/speaker_mute.sh
@@ -1,3 +1,5 @@
+#! /bin/sh
+
 LABEL_FILE=`grep -l pcf8574a /sys/class/gpio/*/*label`
 BASE_FILE=`dirname $LABEL_FILE`/base
 BASE=`cat $BASE_FILE`

--- a/scripts/speaker_unmute.sh
+++ b/scripts/speaker_unmute.sh
@@ -1,3 +1,5 @@
+#! /bin/sh
+
 LABEL_FILE=`grep -l pcf8574a /sys/class/gpio/*/*label`
 BASE_FILE=`dirname $LABEL_FILE`/base
 BASE=`cat $BASE_FILE`

--- a/testitforme.sh
+++ b/testitforme.sh
@@ -1,3 +1,5 @@
+#! /bin/sh
+
 echo "version"
 uname -r
 echo ""


### PR DESCRIPTION
I am using Ansible to configure some CHIPs... OR actually just one CHIP at the moment...  

In doing so I automatically pull a clone of the Tzatziffy git repository and then want to run overlay/chip/load.sh but Ansible refuses as the file type shows up as a plain text file.  Adding a standard header (#! /bin/sh) to this script solves the problem.

I fixed all other shell scripts in this repository that did not already specify a shell interpreter while I was at it (and one that did but had a space in front of the #.